### PR TITLE
gets rid of eslint errors in schema.types.ts

### DIFF
--- a/server/src/graphql/schema.types.ts
+++ b/server/src/graphql/schema.types.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/ban-types */
+
 import { GraphQLResolveInfo } from 'graphql'
 export type Maybe<T> = T | null
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] }


### PR DESCRIPTION
Disables ESLint checking for `@typescript-eslint/ban-types` so we can use `{}` as a type. I checked upstream, it also uses `{}`. I don't know why this wasn't added there.