### PR TITLE
Change HTTP link to Schema link

### DIFF
--- a/server/src/render.tsx
+++ b/server/src/render.tsx
@@ -1,4 +1,5 @@
-import { ApolloClient, ApolloProvider, HttpLink, InMemoryCache } from '@apollo/client'
+import { ApolloClient, ApolloProvider, InMemoryCache } from '@apollo/client'
+import { SchemaLink } from '@apollo/client/link/schema'
 import { getDataFromTree } from '@apollo/client/react/ssr'
 import { isRedirect, ServerLocation } from '@reach/router'
 import 'cross-fetch/polyfill' // enables fetch in node
@@ -11,24 +12,10 @@ import { Config } from './config'
 
 const Styletron = require('styletron-engine-monolithic')
 
-export function renderApp(req: Request, res: Response) {
+export function renderApp(req: Request, res: Response, schema: any) {
   const apolloClient = new ApolloClient({
     ssrMode: true,
-    link: new HttpLink({
-      uri: `http://127.0.0.1:${Config.appserverPort}/graphql`,
-      credentials: 'same-origin',
-      fetch: async (uri: any, options: any) => {
-        const reqBody = JSON.parse(options!.body! as string)
-        const opName = reqBody.operationName
-        const actionName = reqBody.variables?.action?.actionName
-        const authToken = req.cookies.authToken
-        const headers = authToken ? { ...options.headers, 'x-authtoken': authToken } : options.headers
-        return fetch(`${uri}?opName=${opName}${actionName ? `&actionName=${actionName}` : ''}`, {
-          ...options,
-          headers,
-        })
-      },
-    }),
+    link: new SchemaLink({ schema }),
     cache: new InMemoryCache(),
   })
 

--- a/server/src/server.ts
+++ b/server/src/server.ts
@@ -45,7 +45,7 @@ server.express.get('/', (req, res) => {
 
 server.express.get('/app/*', (req, res) => {
   console.log('GET /app')
-  renderApp(req, res)
+  renderApp(req, res, server.executableSchema)
 })
 
 server.express.get(


### PR DESCRIPTION
This circumvents requesting data through HTTP and allows us to call directly into api.ts layer of the app and helps with load testing